### PR TITLE
Fix a regression with RegExp.

### DIFF
--- a/src/__tests__/matchRoutes-test.js
+++ b/src/__tests__/matchRoutes-test.js
@@ -403,5 +403,13 @@ describe('matchRoutes', function() {
       ]
     });
 
+    itMatches(routes, '/products/abc', {
+      path: '/products/abc',
+      query: {},
+      route: undefined,
+      trace: [],
+      activeTrace: []
+    });
+
   });
 });

--- a/src/matchRoutes.js
+++ b/src/matchRoutes.js
@@ -55,13 +55,14 @@ function matchRoute(route, path) {
   if (route.pattern) {
     var match = route.pattern.match(path);
 
-    if (route.pattern.isRegex) {
-      match = {_: match};
-    }
+    if (match) {
+      if (route.pattern.isRegex) {
+        match = {_: match};
+      }
 
-    if (match
-        && (!match._ || match._[0] === '/' || match._[0] === '')) {
-      delete match._;
+      if (!match._ || match._[0] === '/' || match._[0] === '') {
+        delete match._;
+      }
     }
 
     return match;


### PR DESCRIPTION
This fixes an issue where a non-matching RegExp pattern would incorrectly result in a match.
