### PR TITLE
support for react version 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "bluebird": "^2.1.1",
-    "react": "^0.10.0"
+    "react": "0.10.0 - 0.11.x"
   },
   "devDependencies": {
     "reactify": "^0.13.1",
@@ -23,8 +23,8 @@
     "eslint-jsx": "git+https://github.com/andreypopp/eslint#jsx",
     "mocha": "^1.19.0",
     "mochify": "^0.9.2",
-    "react": "^0.10.0",
-    "react-tools": "^0.10.0",
+    "react": "0.10.0 - 0.11.x",
+    "react-tools": "0.10.0 - 0.11.x",
     "sinon": "^1.10.0",
     "url-pattern": "^0.6.0"
   },


### PR DESCRIPTION
React v0.11.0 was recently released so the specified peerDependency in rrouter v0.4.0 is failing:

http://facebook.github.io/react/blog/2014/07/17/react-v0.11.html

The only "listed" breaking change is to getDefaultProps(), but you only appear to be using that in your PathnameRouting-test.js file- and it seems like the react v0.11.0 change won't break that instance.

I've tested a local app and things seem to be working with this package.json change.

NOTE: I've also updated the version number to v0.5.0 so you'll have to republish for this change to really take effect.
